### PR TITLE
fix(profiles): added support for swapping profiles

### DIFF
--- a/src/main/java/com/AttackSoundNotifications/AttackSoundNotificationsPlugin.java
+++ b/src/main/java/com/AttackSoundNotifications/AttackSoundNotificationsPlugin.java
@@ -3,6 +3,7 @@
  * Copyright (c) 2018, Raqes <j.raqes@gmail.com>
  * Copyright (c) 2019, Ron Young <https://github.com/raiyni>
  * Copyright (c) 2023, Jacob Browder <https://github.com/DominickCobb-rs>
+ * Copyright (c) 2024, TJ Stein <https://github.com/AverageToaster>
  * All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -55,6 +56,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.chatbox.ChatboxItemSearch;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
@@ -132,6 +134,13 @@ public class AttackSoundNotificationsPlugin extends Plugin
 		pluginPanel.save();
 		clientToolbar.removeNavigation(navButton);
 		log.info("Attack Sounds Notifier stopped!");
+	}
+
+	// Load new profile's attack sound notifications into the plugin panel.
+	@Subscribe
+	public void onProfileChanged(ProfileChanged profileChanged)
+	{
+		pluginPanel.profileChanged();
 	}
 
 	// From the SpecialAttackCounter plugin

--- a/src/main/java/com/AttackSoundNotifications/ui/AttackSoundNotificationsPanel.java
+++ b/src/main/java/com/AttackSoundNotifications/ui/AttackSoundNotificationsPanel.java
@@ -3,6 +3,7 @@
  * Copyright (c) 2018, Kamiel, <https://github.com/Kamielvf>
  * Copyright (c) 2018, Psikoi <https://github.com/psikoi>
  * Copyright (c) 2023, DominickCobb-rs <https://github.com/DominickCobb-rs>
+ * Copyright (c) 2024, TJ Stein <https://github.com/AverageToaster>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -220,8 +221,8 @@ public class AttackSoundNotificationsPanel extends PluginPanel
 				}
 
 			}
-			startup = false;
 		}
+		startup = false;
 	}
 
 	public void save()
@@ -238,6 +239,14 @@ public class AttackSoundNotificationsPanel extends PluginPanel
 	{
 		entryPanelList.remove(panel);
 		save();
+	}
+
+	public void profileChanged()
+	{
+		entryPanelList.clear();
+		entryPanel.removeAll();
+		loadEntryPanels(entryPanel);
+		reloadPanels();
 	}
 
 	// Sounds! //


### PR DESCRIPTION
This change adds in support for swapping profiles with the attack sound plugin, clearing and reinitializing the list of entries on ProfileChanged events.

Also fixed a bug where setup to start saving never happens if the entry list is not defined on startup.

This is my first foray into runelite plugin development/editing, so apologies if I missed anything obvious for updating the plugin.